### PR TITLE
Activate compatibility mode for Elasticsearch 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>
 			<artifactId>elasticsearch-rest-high-level-client</artifactId>
-			<version>7.14.1</version>
+			<version>7.17.9</version>
 <!--
 			<exclusions>
 				<exclusion>

--- a/src/main/java/de/jlo/talendcomp/elasticsearch/ElasticClient.java
+++ b/src/main/java/de/jlo/talendcomp/elasticsearch/ElasticClient.java
@@ -18,6 +18,7 @@ import java.util.StringTokenizer;
 import javax.net.ssl.SSLContext;
 
 import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
@@ -26,11 +27,8 @@ import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.*;
 import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
-import org.elasticsearch.client.RestHighLevelClient;
 
 public class ElasticClient {
 	
@@ -142,7 +140,8 @@ public class ElasticClient {
 		        		.setConnectTimeout(timeout)
                         .setRedirectsEnabled(true)
                         .setRelativeRedirectsAllowed(true)
-		        		.setContentCompressionEnabled(true);
+		        		.setContentCompressionEnabled(true)
+						;
 		    }
 		    
 		});
@@ -173,7 +172,9 @@ public class ElasticClient {
 			defaultHeaders[1] = new BasicHeader("Cache-Control", "no-cache");
 		}
 		rcb.setDefaultHeaders(defaultHeaders);
-		highLevelClient = new RestHighLevelClient(rcb);
+
+		highLevelClient = new RestHighLevelClientBuilder(rcb.build())
+				.setApiCompatibilityMode(true).build();
 		lowLevelClient = highLevelClient.getLowLevelClient();
 	}
 	

--- a/src/main/java/de/jlo/talendcomp/elasticsearch/IndexOutput.java
+++ b/src/main/java/de/jlo/talendcomp/elasticsearch/IndexOutput.java
@@ -12,7 +12,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.xcontent.XContentType;
 
 public class IndexOutput {
 	


### PR DESCRIPTION
The High Level REST Client has been deprecated so there is not client available for ES 8.
https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high.html

However, since version 7.17 it is possible to activate the API compatibility mode in order to instruct ES8 that we wish to communicate with a version 7  client.
https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/migrate-hlrc.html

This PR enables this flag, thus making the component usable with ES 8.